### PR TITLE
FEAT: list 페이지 dynamic rendering 페이지로 만들기

### DIFF
--- a/forum/app/list/page.js
+++ b/forum/app/list/page.js
@@ -2,6 +2,8 @@ import { connectDB } from "@/util/database";
 
 import ListItem from "./ListItem";
 
+export const dynamic = 'force-dynamic'; // 'force-static'
+
 export default async function List() {
   const db = (await connectDB).db('forum'); // collections 이름
   const results = await db.collection('post').find().toArray(); // document 출력


### PR DESCRIPTION
npm run build 후 확인 했을 때, 
list 페이지가 실시간으로 새 글 html을 그려주는 dynamic rendering이 아닌, static rendering으로 되어있어서
dynamic 으로 변경하는 구문 추가